### PR TITLE
Correct input

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,6 +113,7 @@ async def on_pr_open_or_sync(*, action, number, pull_request, repository, sender
         _LOGGER.error(f"on_pr_open_or_sync: no Pull Request head sha found, stopped working!")
         return
 
+    _LOGGER.info(f"on_pr_open_or_sync: repo_url {repo_url} will be used for check-run")
     _LOGGER.info(f"on_pr_open_or_sync: PR commit id {pr_head_sha} will be used for check-run")
 
     resp = await github_api.post(
@@ -135,7 +136,7 @@ async def on_pr_open_or_sync(*, action, number, pull_request, repository, sender
         "github_event_type": "thoth_thamos_advise",
         "github_check_run_id": check_run_id,
         "github_installation_id": installation["id"],
-        "origin": base_repo_url,
+        "origin": repo_url,
         "revision": pr_head_sha,
     }
     async with aiohttp.ClientSession() as session:

--- a/app.py
+++ b/app.py
@@ -139,7 +139,7 @@ async def on_pr_open_or_sync(*, action, number, pull_request, repository, sender
         "revision": pr_head_sha,
     }
     async with aiohttp.ClientSession() as session:
-        resp = await session.post(USER_API_URL, json=json.dumps(data))
+        resp = await session.post(USER_API_URL, json=data)
         _LOGGER.info(f"on_pr_open_or_sync: user-api resp: {resp}")
 
     resp = await github_api.patch(


### PR DESCRIPTION
I tested it locally! This should solve:

```
2020-02-04 13:31:02,682   1 INFO     octomachinery.app.routing.webhooks_dispatcher:61: Got a valid X-GitHub-Event=pull_request with X-GitHub-Delivery=958a9880-4752-11ea-885f-ddcea8c1c792 and X-Hub-Signature=sha1=87221b66a6c1b45d8f03eb51b6fcb1b6f793b18b
2020-02-04 13:31:03,849   1 INFO     aicoe.sesheta:103: on_pr_open_or_sync: working on PR https://github.com/thoth-station/adviser/pull/786 
2020-02-04 13:31:03,850   1 INFO     aicoe.sesheta:116: on_pr_open_or_sync: PR commit id eae3611c18ffe4f93ab5fd1e2e3c5e046b850c1c will be used for check-run
2020-02-04 13:31:04,291   1 INFO     aicoe.sesheta:132: on_pr_open_or_sync: check_run_id: 425394609
2020-02-04 13:31:04,343   1 INFO     aicoe.sesheta:143: on_pr_open_or_sync: user-api resp: <ClientResponse(https://khemenu.thoth-station.ninja/api/v1/qeb-hwt ) [400 BAD REQUEST]>
<CIMultiDictProxy('Server': 'gunicorn/20.0.4', 'Date': 'Tue, 04 Feb 2020 13:31:04 GMT', 'Content-Type': 'application/problem+json', 'Content-Length': '362', 'Access-Control-Allow-Origin': '*', 'X-Thoth-Version': '0.6.0-dev', 'Set-Cookie': 'ae5b4faaab1fe6375d62dbc3b1efaf0d=6d6119dd8b8db1aff8beed6217b1ec41; path=/; HttpOnly; Secure')>
```

the second commit should solves the issue of the wrong input url provided which would not allow artifact creation for the workflow.